### PR TITLE
Set project copyright holder in LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 BSD 3-Clause License
 
-Copyright (c) 2024, mathsoftware
+Copyright (c) 2024, Tobias Briones
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:


### PR DESCRIPTION
It sets the correct copyright holder name to the project license.